### PR TITLE
removed filetype specification for floating window

### DIFF
--- a/lua/nvim-jqx/floating.lua
+++ b/lua/nvim-jqx/floating.lua
@@ -49,12 +49,7 @@ local function floating_window(geometry)
    return buf
 end
 
-local function set_fw_opts(buf, ft)
-   if ft == 'json' then
-	  vim.api.nvim_buf_set_option(buf, 'filetype', 'json')
-   elseif ft == 'yaml' then
-	  vim.api.nvim_buf_set_option(buf, 'filetype', 'yaml')
-   end
+local function set_fw_opts(buf)
    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'wipe')
    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
    vim.api.nvim_buf_set_option(buf, 'readonly', true)

--- a/lua/nvim-jqx/init.lua
+++ b/lua/nvim-jqx/init.lua
@@ -59,7 +59,7 @@ local function query_jq(q)
    table.insert(query_results, 1, fw.centre_string(user_query))
    table.insert(query_results, 2, '')
    vim.api.nvim_buf_set_lines(floating_buf, 0, -1, true, query_results)
-   fw.set_fw_opts(floating_buf, ft)
+   fw.set_fw_opts(floating_buf)
    vim.cmd('execute "normal! gg"')
 end
 


### PR DESCRIPTION
Removed filetype specification for floating window:  apparently it breaks with TreeSitter??

I am not entirely sure what is causing this problem, however the fix seems to get rid of it.