### PR TITLE
implemented possibility to show keys unsorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ If you prefer key-mappings rather than commands simply bind
 ```
 nmap ... <Plug>JqxList
 ```
+The list of json keys is sorted alphabetically in the quickfix window: if instead you prefer having it in the same order as they appear in the original file, override the default configuration with (notice it requires `jq >= 1.5`)
+```
+lua require('nvim-jqx.config').sort = false
+```
 The default key to open a query in floating window is `X`: you can ovverride it with
 ```
 lua require('nvim-jqx.config').query_key = ...

--- a/doc/jqx.txt
+++ b/doc/jqx.txt
@@ -127,6 +127,12 @@ Two commands are exposed to the user: `JqxList` and `JqxQuery`.
   There is no interface exposed for `JqxQuery`, so you
   would do `nnoremap ... <cmd> JqxQuery` .
 
+  The list of json keys is sorted alphabetically in the quickfix window:
+  if instead you prefer having it in the same order as they appear in the original file,
+  override the default configuration with (notice it requires `jq >= 1.5`)
+  `lua require('nvim-jqx.config').sort = false`
+
+
   The default key to open a query in floating window is `X`: you can ovverride it with
   `lua require('nvim-jqx.config').query_key = ...`
 

--- a/lua/nvim-jqx/config.lua
+++ b/lua/nvim-jqx/config.lua
@@ -6,7 +6,10 @@ local geometry = {
 
 local query_key = 'X'
 
+local sort = false
+
 return {
    geometry = geometry,
    query_key = query_key,
+   sort = sort,
 }

--- a/lua/nvim-jqx/init.lua
+++ b/lua/nvim-jqx/init.lua
@@ -32,7 +32,7 @@ local function jqx_open(type)
    if ft == 'json' then vim.cmd('%! jq .') end
 
    set_qf_maps(ft)
-   jqx.populate_qf(ft, type)
+   jqx.populate_qf(ft, type, config.sort)
 end
 
 local function query_jq(q)

--- a/lua/nvim-jqx/jqx.lua
+++ b/lua/nvim-jqx/jqx.lua
@@ -25,7 +25,7 @@ local function get_key_location(key, ft)
    end
 end
 
-local function populate_qf(ft, type)
+local function populate_qf(ft, type, sort)
    local cmd_lines = {}
    local cur_file = vim.fn.getreg("%")
    if ft == 'json' then
@@ -36,7 +36,8 @@ local function populate_qf(ft, type)
 			table.insert(cmd_lines, key)
 		 end
 	  else
-		 for s in vim.fn.system("jq 'keys[]' "..cur_file):gmatch("[^\r\n]+") do
+		 local get_keys = sort and "jq 'keys[]' "..cur_file or "jq 'keys_unsorted[]' "..cur_file
+		 for s in vim.fn.system(get_keys):gmatch("[^\r\n]+") do
 			local key = s:gsub('%"', ''):gsub('^%s*(.-)%s*$','%1'):gsub(',','')
 			table.insert(cmd_lines, key)
 		 end


### PR DESCRIPTION
This PR is an attempt to address [this request](https://github.com/gennaro-tedesco/nvim-jqx/issues/14) to show json keys in the same order as they appear in the original file (therefore not sorted).
