### PR TITLE
Allow for customization of escape key mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The default key to open a query in floating window is `X`: you can ovverride it 
 ```
 lua require('nvim-jqx.config').query_key = ...
 ```
+The default key to close the floating window is `<ESC>`: you can ovverride it with
+```
+lua require('nvim-jqx.config').close_window_key = ...
+```
 
 ## Feedback
 If you find this plugin useful consider awarding it a ⭐, it is a great way to give feedback! Otherwise, any additional suggestions or merge request is warmly welcome!

--- a/doc/jqx.txt
+++ b/doc/jqx.txt
@@ -136,5 +136,9 @@ Two commands are exposed to the user: `JqxList` and `JqxQuery`.
   The default key to open a query in floating window is `X`: you can ovverride it with
   `lua require('nvim-jqx.config').query_key = ...`
 
+  The default key to close the floating window is `<ESC>`: you can ovverride it with
+  `lua require('nvim-jqx.config').close_window_key = ...`
+
+
 vim:ft=help:et:ts=2:sw=2:sts=2:norl
 

--- a/lua/nvim-jqx/config.lua
+++ b/lua/nvim-jqx/config.lua
@@ -8,8 +8,11 @@ local query_key = 'X'
 
 local sort = true
 
+local close_window_key = '<ESC>'
+
 return {
    geometry = geometry,
    query_key = query_key,
    sort = sort,
+   close_window_key = close_window_key
 }

--- a/lua/nvim-jqx/floating.lua
+++ b/lua/nvim-jqx/floating.lua
@@ -53,7 +53,7 @@ local function set_fw_opts(buf)
    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'wipe')
    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
    vim.api.nvim_buf_set_option(buf, 'readonly', true)
-   vim.api.nvim_buf_set_keymap(buf, 'n', '<ESC>', ':q<CR> <C-w>j', { nowait = true, noremap = true, silent = true })
+   vim.api.nvim_buf_set_keymap(buf, 'n', config.close_window_key, ':q<CR> <C-w>j', { nowait = true, noremap = true, silent = true })
 end
 
 return {


### PR DESCRIPTION
Allow the user of nvim-jqx to specify a key sequence that will close the
floating window.