### PR TITLE
Surround current file path with quotes

### DIFF
--- a/lua/nvim-jqx/init.lua
+++ b/lua/nvim-jqx/init.lua
@@ -43,7 +43,7 @@ local function query_jq(q)
    vim.fn.inputsave()
    local input_query = q=='' and vim.fn.input('enter query: ') or q
    if input_query == '' then vim.cmd('redraw'); print(' '); return nil end
-   local cur_file = vim.fn.getreg("%")
+   local cur_file = string.format([["%s"]], vim.fn.getreg("%"))
    local user_query = ft=='json' and "jq \'."..input_query.."\' "..cur_file or "yq eval \'."..input_query.."\' "..cur_file
    vim.fn.inputrestore()
 

--- a/lua/nvim-jqx/jqx.lua
+++ b/lua/nvim-jqx/jqx.lua
@@ -27,9 +27,9 @@ end
 
 local function populate_qf(ft, type, sort)
    local cmd_lines = {}
-   local cur_file = vim.fn.getreg("%")
+   local cur_file = string.format([["%s"]], vim.fn.getreg("%"))
    if ft == 'json' then
-	  local json_types = {'string', 'number', 'boolean', 'array', 'object', 'null'}
+	  local json_types = {'string', 'number', 'vim.fn.getreg("%")boolean', 'array', 'object', 'null'}
 	  if has_value(json_types, type) then
 		 for s in vim.fn.system("jq -c 'to_entries[] | if (.value|type == \""..type.."\") then .key else empty end' "..cur_file):gmatch("[^\r\n]+") do
 			local key = s:gsub('%"', ''):gsub('^%s*(.-)%s*$','%1'):gsub(',','')

--- a/lua/nvim-jqx/jqx.lua
+++ b/lua/nvim-jqx/jqx.lua
@@ -27,6 +27,7 @@ end
 
 local function populate_qf(ft, type, sort)
    local cmd_lines = {}
+   -- Add quotes to filepaths to account for filenames with spaces
    local cur_file = string.format([["%s"]], vim.fn.getreg("%"))
    if ft == 'json' then
 	  local json_types = {'string', 'number', 'boolean', 'array', 'object', 'null'}
@@ -52,7 +53,9 @@ local function populate_qf(ft, type, sort)
 
    local qf_list = {}
    for _, v in pairs(cmd_lines) do
-	  table.insert(qf_list, {filename = cur_file, lnum = get_key_location(v, ft).row, col = get_key_location(v, ft).col, text = v})
+    -- Cannot reuse variable `cur_file`, quoted filename is not recognized
+    -- Must explicitly resuse register "%"
+	  table.insert(qf_list, {filename = vim.fn.getreg("%"), lnum = get_key_location(v, ft).row, col = get_key_location(v, ft).col, text = v})
    end
 
    vim.fn.setqflist(qf_list, ' ')

--- a/lua/nvim-jqx/jqx.lua
+++ b/lua/nvim-jqx/jqx.lua
@@ -29,7 +29,7 @@ local function populate_qf(ft, type, sort)
    local cmd_lines = {}
    local cur_file = string.format([["%s"]], vim.fn.getreg("%"))
    if ft == 'json' then
-	  local json_types = {'string', 'number', 'vim.fn.getreg("%")boolean', 'array', 'object', 'null'}
+	  local json_types = {'string', 'number', 'boolean', 'array', 'object', 'null'}
 	  if has_value(json_types, type) then
 		 for s in vim.fn.system("jq -c 'to_entries[] | if (.value|type == \""..type.."\") then .key else empty end' "..cur_file):gmatch("[^\r\n]+") do
 			local key = s:gsub('%"', ''):gsub('^%s*(.-)%s*$','%1'):gsub(',','')


### PR DESCRIPTION
In order to work with Json files with spaces in their names, the `cur_file` variables are simply surrounded by quotes