### PR TITLE
docs: reference correct yq distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ For more in-depth description and explanations check the documentation `:h nvim-
 
 ### Yaml files
 
-`nvim-jqx` works on `yaml` files too. It requires, however, to install [yq](https://github.com/mikefarah/yq). Try it out directly with `nvim examples/test.yaml -c JqxList`, or execute `JqxQuery` on a `yaml` file.
+`nvim-jqx` works on `yaml` files too. It requires, however, to install [yq](https://github.com/kislyuk/yq). Try it out directly with `nvim examples/test.yaml -c JqxList`, or execute `JqxQuery` on a `yaml` file.
+
+> ⚠️ this plugin works with the Python implementation of yq by @kislyuk, not to be confused
+> with the Go implementation of yq by @mikefarah.
 
 ## Customisation
 


### PR DESCRIPTION
The readme referred to an incorrect distribution of yq, which is not compatible
with this plugin.

This PR updates the readme to point to the correct distribution and adds a note
to the readme to alleviate the confusion.
