### PR TITLE
fix: Enforce bottom positioning for quickfix and location lists

### DIFF
--- a/lua/nvim-jqx/jqx.lua
+++ b/lua/nvim-jqx/jqx.lua
@@ -90,10 +90,10 @@ local function populate_qf(ft, type, sort)
 
 	if config.use_quickfix then
 		vim.fn.setqflist(qf_list, " ")
-		vim.cmd("copen")
+		vim.cmd("botright copen")
 	else
 		vim.fn.setloclist(0, qf_list, " ")
-		vim.cmd("lopen")
+		vim.cmd("botright lopen")
 	end
 end
 


### PR DESCRIPTION


## Description
This pull request replaces all instances of `:copen` with `:botright copen` to ensure that the quickfix window always opens at the bottom of the layout.

## Rationale
In the original implementation, if the layout is vertically split, invoking `:copen` could cause the new window to open in an unexpected vertical split, potentially splitting a random window. This behavior is undesirable as it disrupts the intended window layout. By using `:botright copen`, the quickfix window consistently appears at the bottom, offering a more predictable and user-friendly experience.

## Impact
- **Before:** `:copen` might split an arbitrary vertical window in a vertically split layout.
- **After:** The quickfix window always opens at the bottom, regardless of the current layout.

Please review the changes and share any feedback or questions.